### PR TITLE
feature(grafana_annotations): add hostname to tags

### DIFF
--- a/plugins/callback/grafana_annotations.py
+++ b/plugins/callback/grafana_annotations.py
@@ -213,7 +213,7 @@ class CallbackModule(CallbackBase):
         data = {
             'time': to_millis(self.start_time),
             'text': text,
-            'tags': ['ansible', 'ansible_event_start', self.playbook]
+            'tags': ['ansible', 'ansible_event_start', self.playbook, self.hostname]
         }
         self._send_annotation(data)
 
@@ -238,7 +238,7 @@ class CallbackModule(CallbackBase):
             'timeEnd': to_millis(end_time),
             'isRegion': True,
             'text': text,
-            'tags': ['ansible', 'ansible_report', self.playbook]
+            'tags': ['ansible', 'ansible_report', self.playbook, self.hostname]
         }
         self._send_annotations(data)
 
@@ -249,7 +249,7 @@ class CallbackModule(CallbackBase):
         data = {
             'time': to_millis(datetime.now()),
             'text': text,
-            'tags': ['ansible', 'ansible_event_failure', self.playbook]
+            'tags': ['ansible', 'ansible_event_failure', self.playbook, self.hostname]
         }
         self.errors += 1
         self._send_annotations(data)


### PR DESCRIPTION
##### SUMMARY

Tags cannot be customized, add hostname to the tags for the annotations so the annotations can be filtered by hosts.

I added hostname to the tags but I'm open to another solution to be more generic.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

grafana_annotations

##### ADDITIONAL INFORMATION

I have one prometheus with one grafana to centralize my logs. I can filter my data based on my host but I cannot filter my annotations. Adding this feature will allow me to filter my host and annotations.