### PR TITLE
Change the GitHub Actions trigger to pull request

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -1,5 +1,6 @@
 name: CI
-on: push
+on:
+- pull_request
 
 jobs:
   sanity:


### PR DESCRIPTION
##### SUMMARY

If we use the "push" keyword, the CI won't be triggered by Pull Requests
made by people who forked the repository. So contributions won't go
through our awesome CI.

I made this change based on : https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#pull-request-event-pull_request

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
