### PR TITLE
grafana_team member elements is str

### DIFF
--- a/plugins/modules/grafana_team.py
+++ b/plugins/modules/grafana_team.py
@@ -52,6 +52,7 @@ options:
       - List of team members (emails).
       - The list can be enforced with C(enforce_members) parameter.
     type: list
+    elements: str
   state:
     description:
       - Delete the members not found in the C(members) parameters from the
@@ -281,7 +282,7 @@ argument_spec = grafana_argument_spec()
 argument_spec.update(
     name=dict(type='str', required=True),
     email=dict(type='str', required=True),
-    members=dict(type='list', required=False),
+    members=dict(type='list', elements='str', required=False),
     enforce_members=dict(type='bool', default=False),
 )
 


### PR DESCRIPTION
##### SUMMARY
Fix  `ERROR: Found 1 validate-modules issue(s) which need to be resolved:
ERROR: plugins/modules/grafana_team.py:0:0: parameter-list-no-elements: Argument 'members' in argument_spec defines type as list but elements is not defined`
##### ISSUE TYPE
- Bugfix Pull Request
