### PR TITLE
Applying changes made in ansible/ansible

### DIFF
--- a/plugins/modules/grafana_dashboard.py
+++ b/plugins/modules/grafana_dashboard.py
@@ -67,10 +67,12 @@ options:
       - Revision of the public grafana dashboard to import
     default: 1
     version_added: '2.10'
-  message:
+  commit_message:
     description:
       - Set a commit message for the version history.
       - Only used when C(state) is C(present).
+      - C(message) alias is deprecated in Ansible 2.10, since it is used internally by Ansible Core Engine.
+    aliases: [ 'message' ]
 extends_documentation_fragment:
 - community.grafana.basic_auth
 - community.grafana.api_key
@@ -85,7 +87,7 @@ EXAMPLES = '''
         grafana_url: http://grafana.company.com
         grafana_api_key: "{{ grafana_api_key }}"
         state: present
-        message: Updated by ansible
+        commit_message: Updated by ansible
         overwrite: yes
         path: /path/to/dashboards/foo.json
 
@@ -346,8 +348,8 @@ def grafana_create_dashboard(module, data):
             # update
             if 'overwrite' in data and data['overwrite']:
                 payload['overwrite'] = True
-            if 'message' in data and data['message']:
-                payload['message'] = data['message']
+            if 'commit_message' in data and data['commit_message']:
+                payload['message'] = data['commit_message']
 
             r, info = fetch_url(module, '%s/api/dashboards/db' % data['grafana_url'],
                                 data=json.dumps(payload), headers=headers, method='POST')
@@ -364,7 +366,7 @@ def grafana_create_dashboard(module, data):
             else:
                 body = json.loads(info['body'])
                 raise GrafanaAPIException('Unable to update the dashboard %s : %s (HTTP: %d)' %
-                                          (uid, body['message'], info['status']))
+                                          (uid, body['commit_message'], info['status']))
         else:
             # unchanged
             result['uid'] = uid
@@ -490,7 +492,8 @@ def main():
         dashboard_id=dict(type='str'),
         dashboard_revision=dict(type='str', default='1'),
         overwrite=dict(type='bool', default=False),
-        message=dict(type='str'),
+        commit_message=dict(type='str', aliases=['message'],
+                            deprecated_aliases=[dict(name='message', version='2.14')]),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,
@@ -498,6 +501,9 @@ def main():
         required_together=[['url_username', 'url_password', 'org_id']],
         mutually_exclusive=[['grafana_user', 'grafana_api_key'], ['uid', 'slug'], ['path', 'dashboard_id']],
     )
+
+    if 'message' in module.params:
+        module.fail_json(msg="'message' is reserved keyword, please change this parameter to 'commit_message'")
 
     try:
         if module.params['state'] == 'present':

--- a/plugins/modules/grafana_dashboard.py
+++ b/plugins/modules/grafana_dashboard.py
@@ -499,7 +499,7 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=False,
         required_together=[['url_username', 'url_password', 'org_id']],
-        mutually_exclusive=[['grafana_user', 'grafana_api_key'], ['uid', 'slug'], ['path', 'dashboard_id']],
+        mutually_exclusive=[['url_username', 'grafana_api_key'], ['uid', 'slug'], ['path', 'dashboard_id']],
     )
 
     if 'message' in module.params:

--- a/plugins/modules/grafana_user.py
+++ b/plugins/modules/grafana_user.py
@@ -247,8 +247,7 @@ def setup_module_object():
         required_if=[
             ['state', 'present', ['name', 'email']],
         ],
-        required_together=grafana_required_together(),
-        mutually_exclusive=grafana_mutually_exclusive(),
+        required_together=grafana_required_together()
     )
     return module
 

--- a/tests/integration/targets/grafana_dashboard/tasks/dashboard-from-file.yml
+++ b/tests/integration/targets/grafana_dashboard/tasks/dashboard-from-file.yml
@@ -11,7 +11,7 @@
     grafana_user: "admin"
     grafana_password: "admin"
     state: present
-    message: Updated by ansible
+    commit_message: Updated by ansible
     path: /tmp/dashboard.json
     overwrite: true
   register: result
@@ -30,7 +30,7 @@
     grafana_user: "admin"
     grafana_password: "admin"
     state: present
-    message: Updated by ansible
+    commit_message: Updated by ansible
     path: /tmp/dashboard.json
     overwrite: true
   register: result

--- a/tests/integration/targets/grafana_dashboard/tasks/dashboard-from-id.yml
+++ b/tests/integration/targets/grafana_dashboard/tasks/dashboard-from-id.yml
@@ -5,7 +5,7 @@
     grafana_user: "admin"
     grafana_password: "admin"
     state: present
-    message: Updated by ansible
+    commit_message: Updated by ansible
     dashboard_id: "6098"
     dashboard_revision: "1"
     overwrite: true
@@ -25,7 +25,7 @@
     grafana_user: "admin"
     grafana_password: "admin"
     state: present
-    message: Updated by ansible
+    commit_message: Updated by ansible
     dashboard_id: "6098"
     dashboard_revision: "1"
     overwrite: true

--- a/tests/integration/targets/grafana_dashboard/tasks/dashboard-from-url.yml
+++ b/tests/integration/targets/grafana_dashboard/tasks/dashboard-from-url.yml
@@ -6,7 +6,7 @@
     grafana_user: "admin"
     grafana_password: "admin"
     state: present
-    message: Updated by ansible
+    commit_message: Updated by ansible
     dashboard_url: https://grafana.com/api/dashboards/6098/revisions/1/download
     overwrite: true
   register: result
@@ -25,7 +25,7 @@
     grafana_user: "admin"
     grafana_password: "admin"
     state: present
-    message: Updated by ansible
+    commit_message: Updated by ansible
     dashboard_url: https://grafana.com/api/dashboards/6098/revisions/1/download
     overwrite: true
   register: result

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -5,3 +5,4 @@ plugins/modules/grafana_datasource.py validate-modules:parameter-type-not-in-doc
 plugins/modules/grafana_datasource.py validate-modules:doc-missing-type
 plugins/modules/grafana_plugin.py validate-modules:parameter-type-not-in-doc
 plugins/modules/grafana_plugin.py validate-modules:doc-missing-type
+plugins/modules/grafana_dashboard.py validate-modules:invalid-argument-name


### PR DESCRIPTION
Changes were made on `grafana_dashboard` after a bugfix. Modules paramters
now have forbidden keywords like `message`.

See https://github.com/ansible/ansible/pull/60051
